### PR TITLE
Add Darcula, Dracula, Material, Monokai, and One Dark themes

### DIFF
--- a/themes/darcula.css
+++ b/themes/darcula.css
@@ -1,0 +1,100 @@
+/* @name: Darcula
+ * @description: Port of JetBrains Darcula with IntelliJ Light companion palette
+ */
+
+:root {
+  --background: oklch(0.9612 0.0000 0.0000);
+  --foreground: oklch(0.1450 0.0000 0.0000);
+  --card: oklch(1.0000 0.0000 0.0000);
+  --card-foreground: oklch(0.1450 0.0000 0.0000);
+  --popover: oklch(1.0000 0.0000 0.0000);
+  --popover-foreground: oklch(0.1450 0.0000 0.0000);
+  --primary: oklch(0.6566 0.0741 242.2199);
+  --primary-foreground: oklch(1.0000 0.0000 0.0000);
+  --secondary: oklch(0.8699 0.0000 0.0000);
+  --secondary-foreground: oklch(0.1450 0.0000 0.0000);
+  --muted: oklch(0.8699 0.0000 0.0000);
+  --muted-foreground: oklch(0.5600 0.0000 0.0000);
+  --accent: oklch(0.8400 0.0750 57.0000);
+  --accent-foreground: oklch(0.1450 0.0000 0.0000);
+  --destructive: oklch(0.7111 0.1816 23.9935);
+  --destructive-foreground: oklch(1.0000 0.0000 0.0000);
+  --border: oklch(0.8699 0.0000 0.0000);
+  --input: oklch(0.8699 0.0000 0.0000);
+  --ring: oklch(0.6566 0.0741 242.2199);
+  --chart-1: oklch(0.6176 0.0856 313.6030);
+  --chart-2: oklch(0.6566 0.0741 242.2199);
+  --chart-3: oklch(0.5887 0.0751 134.4206);
+  --chart-4: oklch(0.7548 0.1504 106.9219);
+  --chart-5: oklch(0.7111 0.1816 23.9935);
+  --sidebar: oklch(0.9612 0.0000 0.0000);
+  --sidebar-foreground: oklch(0.1450 0.0000 0.0000);
+  --sidebar-primary: oklch(0.6566 0.0741 242.2199);
+  --sidebar-primary-foreground: oklch(1.0000 0.0000 0.0000);
+  --sidebar-accent: oklch(0.8699 0.0000 0.0000);
+  --sidebar-accent-foreground: oklch(0.1450 0.0000 0.0000);
+  --sidebar-border: oklch(0.8699 0.0000 0.0000);
+  --sidebar-ring: oklch(0.6566 0.0741 242.2199);
+  --font-sans: Inter, sans-serif;
+  --font-serif: serif;
+  --font-mono: JetBrains Mono, monospace;
+  --radius: 0.25rem;
+  --shadow-2xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.03);
+  --shadow-xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.03);
+  --shadow-sm: 0px 2px 4px 0px hsl(0 0% 0% / 0.05), 0px 1px 2px -1px hsl(0 0% 0% / 0.05);
+  --shadow: 0px 2px 4px 0px hsl(0 0% 0% / 0.05), 0px 1px 2px -1px hsl(0 0% 0% / 0.05);
+  --shadow-md: 0px 2px 4px 0px hsl(0 0% 0% / 0.05), 0px 2px 4px -1px hsl(0 0% 0% / 0.05);
+  --shadow-lg: 0px 2px 4px 0px hsl(0 0% 0% / 0.05), 0px 4px 6px -1px hsl(0 0% 0% / 0.05);
+  --shadow-xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.05), 0px 8px 10px -1px hsl(0 0% 0% / 0.05);
+  --shadow-2xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.13);
+  --tracking-normal: 0rem;
+  --spacing: 0.25rem;
+}
+
+.dark {
+  --background: oklch(0.2891 0.0000 0.0000);
+  --foreground: oklch(0.7733 0.0265 250.0164);
+  --card: oklch(0.3199 0.0045 247.9685);
+  --card-foreground: oklch(0.7733 0.0265 250.0164);
+  --popover: oklch(0.3199 0.0045 247.9685);
+  --popover-foreground: oklch(0.7733 0.0265 250.0164);
+  --primary: oklch(0.6566 0.0741 242.2199);
+  --primary-foreground: oklch(0.2891 0.0000 0.0000);
+  --secondary: oklch(0.4128 0.0000 0.0000);
+  --secondary-foreground: oklch(0.7733 0.0265 250.0164);
+  --muted: oklch(0.4128 0.0000 0.0000);
+  --muted-foreground: oklch(0.7100 0.0220 250.0000);
+  --accent: oklch(0.5000 0.0650 57.0000);
+  --accent-foreground: oklch(0.7733 0.0265 250.0164);
+  --destructive: oklch(0.7111 0.1816 23.9935);
+  --destructive-foreground: oklch(0.7733 0.0265 250.0164);
+  --border: oklch(0.4128 0.0000 0.0000);
+  --input: oklch(0.3199 0.0045 247.9685);
+  --ring: oklch(0.6566 0.0741 242.2199);
+  --chart-1: oklch(0.6176 0.0856 313.6030);
+  --chart-2: oklch(0.6566 0.0741 242.2199);
+  --chart-3: oklch(0.5887 0.0751 134.4206);
+  --chart-4: oklch(0.7548 0.1504 106.9219);
+  --chart-5: oklch(0.7111 0.1816 23.9935);
+  --sidebar: oklch(0.3656 0.0053 236.6460);
+  --sidebar-foreground: oklch(0.7733 0.0265 250.0164);
+  --sidebar-primary: oklch(0.6566 0.0741 242.2199);
+  --sidebar-primary-foreground: oklch(0.7733 0.0265 250.0164);
+  --sidebar-accent: oklch(0.4128 0.0000 0.0000);
+  --sidebar-accent-foreground: oklch(0.7733 0.0265 250.0164);
+  --sidebar-border: oklch(0.4128 0.0000 0.0000);
+  --sidebar-ring: oklch(0.6566 0.0741 242.2199);
+  --font-sans: Inter, sans-serif;
+  --font-serif: serif;
+  --font-mono: JetBrains Mono, monospace;
+  --radius: 0.25rem;
+  --shadow-2xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.05);
+  --shadow-xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.05);
+  --shadow-sm: 0px 2px 4px 0px hsl(0 0% 0% / 0.10), 0px 1px 2px -1px hsl(0 0% 0% / 0.10);
+  --shadow: 0px 2px 4px 0px hsl(0 0% 0% / 0.10), 0px 1px 2px -1px hsl(0 0% 0% / 0.10);
+  --shadow-md: 0px 2px 4px 0px hsl(0 0% 0% / 0.10), 0px 2px 4px -1px hsl(0 0% 0% / 0.10);
+  --shadow-lg: 0px 2px 4px 0px hsl(0 0% 0% / 0.10), 0px 4px 6px -1px hsl(0 0% 0% / 0.10);
+  --shadow-xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.10), 0px 8px 10px -1px hsl(0 0% 0% / 0.10);
+  --shadow-2xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.25);
+}
+

--- a/themes/dracula.css
+++ b/themes/dracula.css
@@ -1,0 +1,100 @@
+/* @name: Dracula
+ * @description: Port of Dracula (draculatheme.com, MIT) with a soft lavender light companion palette
+ */
+
+:root {
+  --background: oklch(0.9811 0.0093 286.2276);
+  --foreground: oklch(0.2882 0.0221 277.5087);
+  --card: oklch(1.0000 0.0000 0.0000);
+  --card-foreground: oklch(0.2882 0.0221 277.5087);
+  --popover: oklch(1.0000 0.0000 0.0000);
+  --popover-foreground: oklch(0.2882 0.0221 277.5087);
+  --primary: oklch(0.7420 0.1485 301.8831);
+  --primary-foreground: oklch(0.9811 0.0093 286.2276);
+  --secondary: oklch(0.9166 0.0175 286.0485);
+  --secondary-foreground: oklch(0.2882 0.0221 277.5087);
+  --muted: oklch(0.9166 0.0175 286.0485);
+  --muted-foreground: oklch(0.6000 0.0650 270.0863);
+  --accent: oklch(0.8600 0.1000 340.0000);
+  --accent-foreground: oklch(0.2882 0.0221 277.5087);
+  --destructive: oklch(0.6822 0.2063 24.4310);
+  --destructive-foreground: oklch(0.9811 0.0093 286.2276);
+  --border: oklch(0.9166 0.0175 286.0485);
+  --input: oklch(0.9166 0.0175 286.0485);
+  --ring: oklch(0.7420 0.1485 301.8831);
+  --chart-1: oklch(0.7420 0.1485 301.8831);
+  --chart-2: oklch(0.8826 0.0934 212.8465);
+  --chart-3: oklch(0.8710 0.2195 148.0249);
+  --chart-4: oklch(0.9553 0.1342 112.7571);
+  --chart-5: oklch(0.6822 0.2063 24.4310);
+  --sidebar: oklch(0.9811 0.0093 286.2276);
+  --sidebar-foreground: oklch(0.2882 0.0221 277.5087);
+  --sidebar-primary: oklch(0.7420 0.1485 301.8831);
+  --sidebar-primary-foreground: oklch(0.9811 0.0093 286.2276);
+  --sidebar-accent: oklch(0.9166 0.0175 286.0485);
+  --sidebar-accent-foreground: oklch(0.2882 0.0221 277.5087);
+  --sidebar-border: oklch(0.9166 0.0175 286.0485);
+  --sidebar-ring: oklch(0.7420 0.1485 301.8831);
+  --font-sans: Inter, sans-serif;
+  --font-serif: serif;
+  --font-mono: JetBrains Mono, monospace;
+  --radius: 0.375rem;
+  --shadow-2xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.03);
+  --shadow-xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.03);
+  --shadow-sm: 0px 2px 4px 0px hsl(0 0% 0% / 0.05), 0px 1px 2px -1px hsl(0 0% 0% / 0.05);
+  --shadow: 0px 2px 4px 0px hsl(0 0% 0% / 0.05), 0px 1px 2px -1px hsl(0 0% 0% / 0.05);
+  --shadow-md: 0px 2px 4px 0px hsl(0 0% 0% / 0.05), 0px 2px 4px -1px hsl(0 0% 0% / 0.05);
+  --shadow-lg: 0px 2px 4px 0px hsl(0 0% 0% / 0.05), 0px 4px 6px -1px hsl(0 0% 0% / 0.05);
+  --shadow-xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.05), 0px 8px 10px -1px hsl(0 0% 0% / 0.05);
+  --shadow-2xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.13);
+  --tracking-normal: 0rem;
+  --spacing: 0.25rem;
+}
+
+.dark {
+  --background: oklch(0.2882 0.0221 277.5087);
+  --foreground: oklch(0.9775 0.0079 106.5451);
+  --card: oklch(0.2554 0.0188 280.4884);
+  --card-foreground: oklch(0.9775 0.0079 106.5451);
+  --popover: oklch(0.2554 0.0188 280.4884);
+  --popover-foreground: oklch(0.9775 0.0079 106.5451);
+  --primary: oklch(0.7420 0.1485 301.8831);
+  --primary-foreground: oklch(0.2554 0.0188 280.4884);
+  --secondary: oklch(0.4028 0.0322 277.8320);
+  --secondary-foreground: oklch(0.9775 0.0079 106.5451);
+  --muted: oklch(0.4028 0.0322 277.8320);
+  --muted-foreground: oklch(0.7000 0.0550 270.0863);
+  --accent: oklch(0.5000 0.0900 330.0000);
+  --accent-foreground: oklch(0.9775 0.0079 106.5451);
+  --destructive: oklch(0.6822 0.2063 24.4310);
+  --destructive-foreground: oklch(0.9775 0.0079 106.5451);
+  --border: oklch(0.4028 0.0322 277.8320);
+  --input: oklch(0.2485 0.0207 284.7914);
+  --ring: oklch(0.7420 0.1485 301.8831);
+  --chart-1: oklch(0.7420 0.1485 301.8831);
+  --chart-2: oklch(0.8826 0.0934 212.8465);
+  --chart-3: oklch(0.8710 0.2195 148.0249);
+  --chart-4: oklch(0.9553 0.1342 112.7571);
+  --chart-5: oklch(0.6822 0.2063 24.4310);
+  --sidebar: oklch(0.2554 0.0188 280.4884);
+  --sidebar-foreground: oklch(0.9775 0.0079 106.5451);
+  --sidebar-primary: oklch(0.7420 0.1485 301.8831);
+  --sidebar-primary-foreground: oklch(0.9775 0.0079 106.5451);
+  --sidebar-accent: oklch(0.4028 0.0322 277.8320);
+  --sidebar-accent-foreground: oklch(0.9775 0.0079 106.5451);
+  --sidebar-border: oklch(0.4028 0.0322 277.8320);
+  --sidebar-ring: oklch(0.7420 0.1485 301.8831);
+  --font-sans: Inter, sans-serif;
+  --font-serif: serif;
+  --font-mono: JetBrains Mono, monospace;
+  --radius: 0.375rem;
+  --shadow-2xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.05);
+  --shadow-xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.05);
+  --shadow-sm: 0px 2px 4px 0px hsl(0 0% 0% / 0.10), 0px 1px 2px -1px hsl(0 0% 0% / 0.10);
+  --shadow: 0px 2px 4px 0px hsl(0 0% 0% / 0.10), 0px 1px 2px -1px hsl(0 0% 0% / 0.10);
+  --shadow-md: 0px 2px 4px 0px hsl(0 0% 0% / 0.10), 0px 2px 4px -1px hsl(0 0% 0% / 0.10);
+  --shadow-lg: 0px 2px 4px 0px hsl(0 0% 0% / 0.10), 0px 4px 6px -1px hsl(0 0% 0% / 0.10);
+  --shadow-xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.10), 0px 8px 10px -1px hsl(0 0% 0% / 0.10);
+  --shadow-2xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.25);
+}
+

--- a/themes/monokai.css
+++ b/themes/monokai.css
@@ -1,0 +1,100 @@
+/* @name: Monokai
+ * @description: Port of Monokai with a warm cream light companion palette
+ */
+
+:root {
+  --background: oklch(0.9798 0.0045 78.2982);
+  --foreground: oklch(0.2737 0.0109 114.8025);
+  --card: oklch(1.0000 0.0000 0.0000);
+  --card-foreground: oklch(0.2737 0.0109 114.8025);
+  --popover: oklch(1.0000 0.0000 0.0000);
+  --popover-foreground: oklch(0.2737 0.0109 114.8025);
+  --primary: oklch(0.7012 0.1812 298.0620);
+  --primary-foreground: oklch(0.9798 0.0045 78.2982);
+  --secondary: oklch(0.9198 0.0116 84.5797);
+  --secondary-foreground: oklch(0.2737 0.0109 114.8025);
+  --muted: oklch(0.9198 0.0116 84.5797);
+  --muted-foreground: oklch(0.5800 0.0288 97.3939);
+  --accent: oklch(0.8700 0.1100 127.0000);
+  --accent-foreground: oklch(0.2737 0.0109 114.8025);
+  --destructive: oklch(0.6416 0.2400 7.4666);
+  --destructive-foreground: oklch(0.9798 0.0045 78.2982);
+  --border: oklch(0.9198 0.0116 84.5797);
+  --input: oklch(0.9198 0.0116 84.5797);
+  --ring: oklch(0.7012 0.1812 298.0620);
+  --chart-1: oklch(0.7012 0.1812 298.0620);
+  --chart-2: oklch(0.8269 0.1080 211.9627);
+  --chart-3: oklch(0.8414 0.2044 127.2862);
+  --chart-4: oklch(0.8792 0.1255 103.1820);
+  --chart-5: oklch(0.6416 0.2400 7.4666);
+  --sidebar: oklch(0.9798 0.0045 78.2982);
+  --sidebar-foreground: oklch(0.2737 0.0109 114.8025);
+  --sidebar-primary: oklch(0.7012 0.1812 298.0620);
+  --sidebar-primary-foreground: oklch(0.9798 0.0045 78.2982);
+  --sidebar-accent: oklch(0.9198 0.0116 84.5797);
+  --sidebar-accent-foreground: oklch(0.2737 0.0109 114.8025);
+  --sidebar-border: oklch(0.9198 0.0116 84.5797);
+  --sidebar-ring: oklch(0.7012 0.1812 298.0620);
+  --font-sans: Inter, sans-serif;
+  --font-serif: serif;
+  --font-mono: JetBrains Mono, monospace;
+  --radius: 0.375rem;
+  --shadow-2xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.03);
+  --shadow-xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.03);
+  --shadow-sm: 0px 2px 4px 0px hsl(0 0% 0% / 0.05), 0px 1px 2px -1px hsl(0 0% 0% / 0.05);
+  --shadow: 0px 2px 4px 0px hsl(0 0% 0% / 0.05), 0px 1px 2px -1px hsl(0 0% 0% / 0.05);
+  --shadow-md: 0px 2px 4px 0px hsl(0 0% 0% / 0.05), 0px 2px 4px -1px hsl(0 0% 0% / 0.05);
+  --shadow-lg: 0px 2px 4px 0px hsl(0 0% 0% / 0.05), 0px 4px 6px -1px hsl(0 0% 0% / 0.05);
+  --shadow-xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.05), 0px 8px 10px -1px hsl(0 0% 0% / 0.05);
+  --shadow-2xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.13);
+  --tracking-normal: 0rem;
+  --spacing: 0.25rem;
+}
+
+.dark {
+  --background: oklch(0.2737 0.0109 114.8025);
+  --foreground: oklch(0.9775 0.0079 106.5451);
+  --card: oklch(0.2371 0.0058 121.8890);
+  --card-foreground: oklch(0.9775 0.0079 106.5451);
+  --popover: oklch(0.2371 0.0058 121.8890);
+  --popover-foreground: oklch(0.9775 0.0079 106.5451);
+  --primary: oklch(0.7012 0.1812 298.0620);
+  --primary-foreground: oklch(0.2371 0.0058 121.8890);
+  --secondary: oklch(0.3574 0.0184 103.0021);
+  --secondary-foreground: oklch(0.9775 0.0079 106.5451);
+  --muted: oklch(0.3574 0.0184 103.0021);
+  --muted-foreground: oklch(0.7000 0.0288 97.3939);
+  --accent: oklch(0.5000 0.1000 125.0000);
+  --accent-foreground: oklch(0.9775 0.0079 106.5451);
+  --destructive: oklch(0.6416 0.2400 7.4666);
+  --destructive-foreground: oklch(0.9775 0.0079 106.5451);
+  --border: oklch(0.3574 0.0184 103.0021);
+  --input: oklch(0.2466 0.0056 106.8001);
+  --ring: oklch(0.7012 0.1812 298.0620);
+  --chart-1: oklch(0.7012 0.1812 298.0620);
+  --chart-2: oklch(0.8269 0.1080 211.9627);
+  --chart-3: oklch(0.8414 0.2044 127.2862);
+  --chart-4: oklch(0.8792 0.1255 103.1820);
+  --chart-5: oklch(0.6416 0.2400 7.4666);
+  --sidebar: oklch(0.2371 0.0058 121.8890);
+  --sidebar-foreground: oklch(0.9775 0.0079 106.5451);
+  --sidebar-primary: oklch(0.7012 0.1812 298.0620);
+  --sidebar-primary-foreground: oklch(0.9775 0.0079 106.5451);
+  --sidebar-accent: oklch(0.3574 0.0184 103.0021);
+  --sidebar-accent-foreground: oklch(0.9775 0.0079 106.5451);
+  --sidebar-border: oklch(0.3574 0.0184 103.0021);
+  --sidebar-ring: oklch(0.7012 0.1812 298.0620);
+  --font-sans: Inter, sans-serif;
+  --font-serif: serif;
+  --font-mono: JetBrains Mono, monospace;
+  --radius: 0.375rem;
+  --shadow-2xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.05);
+  --shadow-xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.05);
+  --shadow-sm: 0px 2px 4px 0px hsl(0 0% 0% / 0.10), 0px 1px 2px -1px hsl(0 0% 0% / 0.10);
+  --shadow: 0px 2px 4px 0px hsl(0 0% 0% / 0.10), 0px 1px 2px -1px hsl(0 0% 0% / 0.10);
+  --shadow-md: 0px 2px 4px 0px hsl(0 0% 0% / 0.10), 0px 2px 4px -1px hsl(0 0% 0% / 0.10);
+  --shadow-lg: 0px 2px 4px 0px hsl(0 0% 0% / 0.10), 0px 4px 6px -1px hsl(0 0% 0% / 0.10);
+  --shadow-xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.10), 0px 8px 10px -1px hsl(0 0% 0% / 0.10);
+  --shadow-2xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.25);
+}
+

--- a/themes/one_dark.css
+++ b/themes/one_dark.css
@@ -1,0 +1,100 @@
+/* @name: One Dark
+ * @description: Port of Atom One Dark with One Light companion palette
+ */
+
+:root {
+  --background: oklch(0.9851 0.0000 0.0000);
+  --foreground: oklch(0.3496 0.0141 274.5028);
+  --card: oklch(1.0000 0.0000 0.0000);
+  --card-foreground: oklch(0.3496 0.0141 274.5028);
+  --popover: oklch(1.0000 0.0000 0.0000);
+  --popover-foreground: oklch(0.3496 0.0141 274.5028);
+  --primary: oklch(0.7304 0.1213 245.2972);
+  --primary-foreground: oklch(0.9851 0.0000 0.0000);
+  --secondary: oklch(0.9222 0.0013 286.3733);
+  --secondary-foreground: oklch(0.3496 0.0141 274.5028);
+  --muted: oklch(0.9222 0.0013 286.3733);
+  --muted-foreground: oklch(0.5600 0.0225 262.9131);
+  --accent: oklch(0.8500 0.0550 310.0000);
+  --accent-foreground: oklch(0.3496 0.0141 274.5028);
+  --destructive: oklch(0.6709 0.1448 16.9989);
+  --destructive-foreground: oklch(0.9851 0.0000 0.0000);
+  --border: oklch(0.9222 0.0013 286.3733);
+  --input: oklch(0.9222 0.0013 286.3733);
+  --ring: oklch(0.7304 0.1213 245.2972);
+  --chart-1: oklch(0.6936 0.1635 318.2073);
+  --chart-2: oklch(0.7304 0.1213 245.2972);
+  --chart-3: oklch(0.7683 0.1103 133.0000);
+  --chart-4: oklch(0.8249 0.0970 82.2597);
+  --chart-5: oklch(0.6709 0.1448 16.9989);
+  --sidebar: oklch(0.9851 0.0000 0.0000);
+  --sidebar-foreground: oklch(0.3496 0.0141 274.5028);
+  --sidebar-primary: oklch(0.7304 0.0728 245.2972);
+  --sidebar-primary-foreground: oklch(0.9851 0.0000 0.0000);
+  --sidebar-accent: oklch(0.9222 0.0120 295.0000);
+  --sidebar-accent-foreground: oklch(0.3496 0.0141 274.5028);
+  --sidebar-border: oklch(0.9222 0.0013 286.3733);
+  --sidebar-ring: oklch(0.7304 0.1213 245.2972);
+  --font-sans: Inter, sans-serif;
+  --font-serif: serif;
+  --font-mono: JetBrains Mono, monospace;
+  --radius: 0.375rem;
+  --shadow-2xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.03);
+  --shadow-xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.03);
+  --shadow-sm: 0px 2px 4px 0px hsl(0 0% 0% / 0.05), 0px 1px 2px -1px hsl(0 0% 0% / 0.05);
+  --shadow: 0px 2px 4px 0px hsl(0 0% 0% / 0.05), 0px 1px 2px -1px hsl(0 0% 0% / 0.05);
+  --shadow-md: 0px 2px 4px 0px hsl(0 0% 0% / 0.05), 0px 2px 4px -1px hsl(0 0% 0% / 0.05);
+  --shadow-lg: 0px 2px 4px 0px hsl(0 0% 0% / 0.05), 0px 4px 6px -1px hsl(0 0% 0% / 0.05);
+  --shadow-xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.05), 0px 8px 10px -1px hsl(0 0% 0% / 0.05);
+  --shadow-2xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.13);
+  --tracking-normal: 0rem;
+  --spacing: 0.25rem;
+}
+
+.dark {
+  --background: oklch(0.2925 0.0157 264.2965);
+  --foreground: oklch(0.7621 0.0202 262.9873);
+  --card: oklch(0.2630 0.0127 258.3725);
+  --card-foreground: oklch(0.7621 0.0202 262.9873);
+  --popover: oklch(0.2630 0.0127 258.3725);
+  --popover-foreground: oklch(0.7621 0.0202 262.9873);
+  --primary: oklch(0.7304 0.1213 245.2972);
+  --primary-foreground: oklch(0.2630 0.0127 258.3725);
+  --secondary: oklch(0.3863 0.0235 265.6941);
+  --secondary-foreground: oklch(0.7621 0.0202 262.9873);
+  --muted: oklch(0.3863 0.0235 265.6941);
+  --muted-foreground: oklch(0.7000 0.0225 262.9131);
+  --accent: oklch(0.5000 0.0550 305.0000);
+  --accent-foreground: oklch(0.7621 0.0202 262.9873);
+  --destructive: oklch(0.6709 0.1448 16.9989);
+  --destructive-foreground: oklch(0.7621 0.0202 262.9873);
+  --border: oklch(0.3863 0.0235 265.6941);
+  --input: oklch(0.2630 0.0127 258.3725);
+  --ring: oklch(0.7304 0.1213 245.2972);
+  --chart-1: oklch(0.6936 0.1635 318.2073);
+  --chart-2: oklch(0.7304 0.1213 245.2972);
+  --chart-3: oklch(0.7683 0.1103 133.0000);
+  --chart-4: oklch(0.8249 0.0970 82.2597);
+  --chart-5: oklch(0.6709 0.1448 16.9989);
+  --sidebar: oklch(0.2630 0.0127 258.3725);
+  --sidebar-foreground: oklch(0.7621 0.0202 262.9873);
+  --sidebar-primary: oklch(0.7304 0.0728 245.2972);
+  --sidebar-primary-foreground: oklch(0.7621 0.0202 262.9873);
+  --sidebar-accent: oklch(0.3863 0.0300 285.0000);
+  --sidebar-accent-foreground: oklch(0.7621 0.0202 262.9873);
+  --sidebar-border: oklch(0.3863 0.0235 265.6941);
+  --sidebar-ring: oklch(0.7304 0.1213 245.2972);
+  --font-sans: Inter, sans-serif;
+  --font-serif: serif;
+  --font-mono: JetBrains Mono, monospace;
+  --radius: 0.375rem;
+  --shadow-2xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.05);
+  --shadow-xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.05);
+  --shadow-sm: 0px 2px 4px 0px hsl(0 0% 0% / 0.10), 0px 1px 2px -1px hsl(0 0% 0% / 0.10);
+  --shadow: 0px 2px 4px 0px hsl(0 0% 0% / 0.10), 0px 1px 2px -1px hsl(0 0% 0% / 0.10);
+  --shadow-md: 0px 2px 4px 0px hsl(0 0% 0% / 0.10), 0px 2px 4px -1px hsl(0 0% 0% / 0.10);
+  --shadow-lg: 0px 2px 4px 0px hsl(0 0% 0% / 0.10), 0px 4px 6px -1px hsl(0 0% 0% / 0.10);
+  --shadow-xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.10), 0px 8px 10px -1px hsl(0 0% 0% / 0.10);
+  --shadow-2xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.25);
+}
+


### PR DESCRIPTION
Ports 4 themes from autobrr/qui#2117 as sideloadable community themes.

# Darcula

<img width="2560" height="1392" alt="Screenshot 2026-07-27 100320" src="https://github.com/user-attachments/assets/4b18d5a0-77c7-4ab2-9e69-e763530b40c2" />

# Dracula

<img width="2560" height="1392" alt="Screenshot 2026-07-27 100358" src="https://github.com/user-attachments/assets/30101304-a286-45b6-acb1-0dacdb21bf78" />

# Monokai
<img width="2560" height="1392" alt="Screenshot 2026-07-27 100415" src="https://github.com/user-attachments/assets/579e13f7-d84c-4236-83bf-26abd404fe29" />




# One Dark
<img width="2560" height="1392" alt="Screenshot 2026-07-27 102403" src="https://github.com/user-attachments/assets/7c690036-9c21-43d2-b0b5-a92d3be9dbf8" />